### PR TITLE
fix(nannysvc) : 반환값 형 변환

### DIFF
--- a/src/manage/db/po_fa/ManagePoFaEnv.cpp
+++ b/src/manage/db/po_fa/ManagePoFaEnv.cpp
@@ -92,7 +92,7 @@ INT32					CManagePoFaEnv::InitHash(UINT32 nID)
 	{
 		strOrgValue = SPrintf("%s,"
 							"%d,", 
-							GetHdrHashInfo(pdpfe),
+							GetHdrHashInfo(pdpfe).c_str(),
 							pdpfe->nSysOffMaxWorkTime);
 
 		{


### PR DESCRIPTION
error: cannot pass object of non-trivial type 'String' (aka 'basic_string<char>') through variadic function; call will abort at runtime [-Wnon-pod-varargs] 수정