### PR TITLE
fix(nannysvc) : 반환 String 사용 오류 수정

### DIFF
--- a/src/manage/db/po_etc/ManagePoHostNotifyUnit.cpp
+++ b/src/manage/db/po_etc/ManagePoHostNotifyUnit.cpp
@@ -76,7 +76,7 @@ INT32					CManagePoHostNotifyUnit::GetHash(UINT32 nID, String& strOrgValue)
 		strItemHash = SPrintf("%s,"
 			"%u,%u,%u,%u,%u,"
 			"%u,%s,", 
-			GetHdrHashInfo(pdphnu),
+			GetHdrHashInfo(pdphnu).c_str(),
 			pdphnu->nSchTime,
 			pdphnu->nPosType, pdphnu->nShowSize, pdphnu->nShowPos, pdphnu->nShowTime,
 			pdphnu->nMsgFmtType, pdphnu->strMsgInfo.c_str());


### PR DESCRIPTION
error: cannot pass object of non-trivial type 'String' (aka 'basic_string<char>') through variadic function; call will abort at runtime [-Wnon-pod-varargs] 수정