### PR TITLE
fix(nannysvc) : 경로 구분자 변경

### DIFF
--- a/src/logic/mgr/log/LogicMgrLogRsBk.cpp
+++ b/src/logic/mgr/log/LogicMgrLogRsBk.cpp
@@ -186,7 +186,7 @@ void		CLogicMgrLogRsBk::SetLogRsBk(DB_LOG_RS_BK& data)
 			data.strSubjectPath.find("%") == string::npos  && data.strSubjectName.find("%") == string::npos )
 		{
 
-			WriteLogN("[%s] remain evt log to file : op[%d]:bs[%d]:bk[%d]:fi[%s\\%s:%s\\%s][%s]", 
+			WriteLogN("[%s] remain evt log to file : op[%d]:bs[%d]:bk[%d]:fi[%s/%s:%s/%s][%s]", 
 				m_strLogicName.c_str(),
 				data.nOpType, data.nBackupSize, data.nBackupTime,
 				data.strSubjectPath.c_str(), data.strSubjectName.c_str(), 


### PR DESCRIPTION
Windows 경로 구분자 '\\'에서 리눅스 경로 구분자 '/'로 변경