### PR TITLE
fix(nannysvc) : calloc 인자 오류 수정

### DIFF
--- a/src/thread/ThreadPoFaOp.cpp
+++ b/src/thread/ThreadPoFaOp.cpp
@@ -641,7 +641,7 @@ INT32		CThreadPoFaOp::CheckNotifyFile()
 		return -2;
 	}
 
-	pBuffer = (char *)calloc( nLength+1, sizeof(char *) );
+	pBuffer = (char *)calloc( nLength+1, sizeof(char) );
 	if(pBuffer == NULL)
 	{
 		WriteLogE("fail to allocate memory (%d) : [%s]", errno, m_strThreadName.c_str());


### PR DESCRIPTION
warning: Result of 'calloc' is converted to a pointer of type 'char', which is incompatible with sizeof operand type 'char *' 수정